### PR TITLE
Add skips to all but first tests

### DIFF
--- a/compress_test.rb
+++ b/compress_test.rb
@@ -10,16 +10,19 @@ class CompressTest < Minitest::Test
   end
 
   def test_it_compresses_two_of_the_same_letter
+    skip
     result = compress("aa")
     assert_equal "a2", result
   end
 
   def test_if_the_code_is_longer_it_returns_original_string
+    skip
     result = compress("ab")
     assert_equal "ab", result
   end
 
   def test_it_compresses_mulitple_letters
+    skip
     result = compress("aaabbccccccc")
     assert_equal "a3b2c7", result
   end

--- a/replace_test.rb
+++ b/replace_test.rb
@@ -10,16 +10,19 @@ class ReplaceTest < Minitest::Test
   end
 
   def test_it_replaces_multiple_spaces
+    skip
     result = replace("Foo Bar Baz")
     assert_equal "Foo%20Bar%20Baz", result
   end
 
   def test_it_does_not_replace_trailing_spaces_but_removes_them
+    skip
     result = replace("FooBar  ")
     assert_equal "FooBar", result
   end
 
   def test_it_replaces_spaces_and_removes_trailing_ones
+    skip
     result = replace("Foo Bar Baz     ")
     assert_equal "Foo%20Bar%20Baz", result
   end

--- a/rotator_test.rb
+++ b/rotator_test.rb
@@ -14,6 +14,7 @@ class RotatorTest < Minitest::Test
   end
 
   def test_it_rotates_four
+    skip
     result = rotate(@four)
     assert_equal [[13,9,5,1],[14,10,6,2],[15,11,7,3],[16,12,8,4]], result
   end


### PR DESCRIPTION
Simple convenience thing, as the first thing I found myself doing was skipping tests to make test output more readable/manageable when I first started an exercise.  This follows exercism's style, and fits with the idea of starting small and gradually making more complex tests pass.
